### PR TITLE
feat: #3 방 생성, 참여 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation 'org.redisson:redisson-spring-boot-starter:3.17.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/mutsa/yewon/talksparkbe/TalkSparkBeApplication.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/TalkSparkBeApplication.java
@@ -2,8 +2,10 @@ package mutsa.yewon.talksparkbe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TalkSparkBeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/config/RedissonConfig.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/config/RedissonConfig.java
@@ -1,0 +1,25 @@
+package mutsa.yewon.talksparkbe.domain.game.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        // 단일 노드 Redis 서버 주소 설정
+        config.useSingleServer()
+                .setAddress("redis://127.0.0.1:6379") // Redis 서버 주소와 포트
+                .setConnectionPoolSize(10) // 연결 풀 크기 설정
+                .setConnectionMinimumIdleSize(5); // 최소 유휴 연결 수 설정
+
+        return Redisson.create(config);
+    }
+
+}
+

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/RoomController.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/RoomController.java
@@ -1,0 +1,32 @@
+package mutsa.yewon.talksparkbe.domain.game.controller;
+
+import lombok.RequiredArgsConstructor;
+import mutsa.yewon.talksparkbe.domain.game.controller.request.RoomCreateRequest;
+import mutsa.yewon.talksparkbe.domain.game.controller.request.RoomJoinRequest;
+import mutsa.yewon.talksparkbe.domain.game.service.RoomService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/rooms")
+@RequiredArgsConstructor
+public class RoomController {
+
+    private final RoomService roomService;
+
+    @PostMapping
+    public ResponseEntity<?> roomCreate(@RequestBody RoomCreateRequest roomCreateRequest) {
+        return ResponseEntity.ok(roomService.createRoom(roomCreateRequest));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> roomList() {
+        return ResponseEntity.ok(roomService.listAllRooms());
+    }
+
+    @PostMapping("/join")
+    public ResponseEntity<?> roomJoin(@RequestBody RoomJoinRequest roomJoinRequest) {
+        return ResponseEntity.ok(roomService.joinRoom(roomJoinRequest));
+    }
+
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/request/RoomCreateRequest.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/request/RoomCreateRequest.java
@@ -1,0 +1,25 @@
+package mutsa.yewon.talksparkbe.domain.game.controller.request;
+
+import lombok.Data;
+import mutsa.yewon.talksparkbe.domain.game.entity.Room;
+
+@Data
+public class RoomCreateRequest {
+
+    private String roomName;
+
+    private int maxPeople;
+
+    private int difficulty;
+
+    private Long hostId; // TODO: 임시용. 삭제 혹은 변경 예정
+
+    public Room toRoomEntity() {
+        return Room.builder()
+                .roomName(this.roomName)
+                .maxPeople(this.maxPeople)
+                .difficulty(this.difficulty)
+                .build();
+    }
+
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/request/RoomJoinRequest.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/request/RoomJoinRequest.java
@@ -1,0 +1,12 @@
+package mutsa.yewon.talksparkbe.domain.game.controller.request;
+
+import lombok.Data;
+
+@Data
+public class RoomJoinRequest {
+
+    private Long roomId;
+
+    private Long sparkUserId;
+
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/entity/Room.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/entity/Room.java
@@ -1,0 +1,60 @@
+package mutsa.yewon.talksparkbe.domain.game.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class Room {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long roomId;
+
+    private String roomName; // 방 이름
+
+    private String code;
+
+    private int maxPeople; // 최대 참가자 수
+
+    private int difficulty;
+
+    private boolean isStarted = false;
+    private boolean isFinished = false;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "room")
+    private List<RoomParticipate> roomParticipates = new ArrayList<>();
+
+    @Builder
+    private Room(String roomName, int maxPeople, int difficulty) {
+        this.roomName = roomName;
+        this.maxPeople = maxPeople;
+        this.difficulty = difficulty;
+    }
+
+    public void addRoomParticipate(RoomParticipate roomParticipate) {
+        this.roomParticipates.add(roomParticipate);
+    }
+
+    public void assignRoomParticipate(RoomParticipate roomParticipate) {
+        this.addRoomParticipate(roomParticipate);
+        roomParticipate.assignRoom(this);
+    }
+
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/entity/RoomParticipate.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/entity/RoomParticipate.java
@@ -1,0 +1,40 @@
+package mutsa.yewon.talksparkbe.domain.game.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mutsa.yewon.talksparkbe.domain.sparkUser.entity.SparkUser;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class RoomParticipate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long roomParticipateId;
+
+    @ManyToOne
+    @JoinColumn(name = "spark_user_id")
+    private SparkUser sparkUser;
+
+    @ManyToOne
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    private boolean isOwner;
+
+    @Builder
+    private RoomParticipate(SparkUser sparkUser, Room room, boolean isOwner) {
+        this.sparkUser = sparkUser;
+        this.room = room;
+        this.isOwner = isOwner;
+    }
+
+    public void assignRoom(Room room) {
+        this.room = room;
+    }
+
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/initializer/SparkUserInitializer.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/initializer/SparkUserInitializer.java
@@ -1,0 +1,36 @@
+//package mutsa.yewon.talksparkbe.domain.game.initializer;
+//
+//import lombok.RequiredArgsConstructor;
+//import mutsa.yewon.talksparkbe.domain.sparkUser.entity.SparkUser;
+//import mutsa.yewon.talksparkbe.domain.sparkUser.repository.SparkUserRepository;
+//import org.springframework.boot.CommandLineRunner;
+//import org.springframework.stereotype.Component;
+//
+//@Component
+//@RequiredArgsConstructor
+//public class SparkUserInitializer implements CommandLineRunner {
+//
+//    private final SparkUserRepository sparkUserRepository;
+//
+//    @Override
+//    public void run(String... args) throws Exception {
+//        SparkUser sparkUser1 = SparkUser.builder()
+//                .name("minu")
+//                .kakaoId("111111")
+//                .build();
+//        sparkUserRepository.save(sparkUser1);
+//
+//        SparkUser sparkUser2 = SparkUser.builder()
+//                .name("seungbeom")
+//                .kakaoId("111112")
+//                .build();
+//        sparkUserRepository.save(sparkUser2);
+//
+//        SparkUser sparkUser3 = SparkUser.builder()
+//                .name("yoonjeong")
+//                .kakaoId("111113")
+//                .build();
+//        sparkUserRepository.save(sparkUser3);
+//    }
+//
+//}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/repository/RoomParticipateRepository.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/repository/RoomParticipateRepository.java
@@ -1,0 +1,7 @@
+package mutsa.yewon.talksparkbe.domain.game.repository;
+
+import mutsa.yewon.talksparkbe.domain.game.entity.RoomParticipate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomParticipateRepository extends JpaRepository<RoomParticipate, Long> {
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/repository/RoomRepository.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/repository/RoomRepository.java
@@ -1,0 +1,17 @@
+package mutsa.yewon.talksparkbe.domain.game.repository;
+
+import mutsa.yewon.talksparkbe.domain.game.entity.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+
+    @Query("select r " +
+            "from Room r " +
+            "join fetch r.roomParticipates rp " +
+            "where rp.isOwner = true and r.isFinished = false ")
+    List<Room> findAllWithParticipates();
+
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/RoomService.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/RoomService.java
@@ -1,0 +1,104 @@
+package mutsa.yewon.talksparkbe.domain.game.service;
+
+import lombok.RequiredArgsConstructor;
+import mutsa.yewon.talksparkbe.domain.game.controller.request.RoomCreateRequest;
+import mutsa.yewon.talksparkbe.domain.game.controller.request.RoomJoinRequest;
+import mutsa.yewon.talksparkbe.domain.game.entity.Room;
+import mutsa.yewon.talksparkbe.domain.game.entity.RoomParticipate;
+import mutsa.yewon.talksparkbe.domain.game.repository.RoomParticipateRepository;
+import mutsa.yewon.talksparkbe.domain.game.repository.RoomRepository;
+import mutsa.yewon.talksparkbe.domain.game.service.response.RoomListResponse;
+import mutsa.yewon.talksparkbe.domain.sparkUser.entity.SparkUser;
+import mutsa.yewon.talksparkbe.domain.sparkUser.repository.SparkUserRepository;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RoomService {
+
+    private final SparkUserRepository sparkUserRepository;
+    private final RoomRepository roomRepository;
+    private final RoomParticipateRepository roomParticipateRepository;
+    private final RedissonClient redissonClient;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String ROOM_COUNT_KEY = "room:participateCount";
+
+    @Transactional
+    public Long createRoom(RoomCreateRequest roomCreateRequest) {
+        SparkUser sparkUser = sparkUserRepository.findById(roomCreateRequest.getHostId()).orElseThrow(() -> new RuntimeException("사람 못찾음"));
+        Room room = roomRepository.save(roomCreateRequest.toRoomEntity());
+
+        RoomParticipate roomParticipate = RoomParticipate.builder().room(room).sparkUser(sparkUser).isOwner(true).build();
+        roomParticipateRepository.save(roomParticipate);
+        room.assignRoomParticipate(roomParticipate);
+
+        redisTemplate.opsForHash().put(ROOM_COUNT_KEY, room.getRoomId().toString(), "1");
+
+        return room.getRoomId();
+    }
+
+    public List<RoomListResponse> listAllRooms() {
+        List<Room> rooms = roomRepository.findAllWithParticipates();
+        List<RoomListResponse> roomListResponses = new ArrayList<>();
+
+        for (Room r : rooms) {
+            RoomListResponse response = RoomListResponse.from(r);
+            response.setHostName(r.getRoomParticipates().get(0).getSparkUser().getName());
+            response.setCurrentPeople(getParticipateCount(r.getRoomId()));
+
+            roomListResponses.add(response);
+        }
+
+        return roomListResponses;
+    }
+
+    @Transactional
+    public boolean joinRoom(RoomJoinRequest roomJoinRequest) {
+        Long roomId = roomJoinRequest.getRoomId();
+        Room room = roomRepository.findById(roomId).orElseThrow(() -> new RuntimeException("방 못찾음"));
+        SparkUser sparkUser = sparkUserRepository.findById(roomJoinRequest.getSparkUserId()).orElseThrow(() -> new RuntimeException("회원 못찾음"));
+
+        // 방에 입장할 때 락을 획득
+        RLock lock = redissonClient.getLock("roomLock:" + roomId);
+
+        try {
+            if (lock.tryLock(5, 10, TimeUnit.SECONDS)) { // 최대 대기 시간 5초, 락 보유 시간 10초로 설정
+                if (canJoin(room)) {
+                    addParticipateToRoom(room, sparkUser);
+                    return true;
+                }
+                return false;
+            } else return false; // 락을 획득하지 못한 경우 (대기 시간 초과)
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        } finally {
+            if (lock.isHeldByCurrentThread()) lock.unlock();
+        }
+    }
+
+    public int getParticipateCount(Long roomId) {
+        String count = (String) redisTemplate.opsForHash().get(ROOM_COUNT_KEY, roomId.toString());
+        return count != null ? Integer.parseInt(count) : 0;
+    }
+    private boolean canJoin(Room room) {
+        int currentCount = getParticipateCount(room.getRoomId());
+        return currentCount < room.getMaxPeople();
+    }
+    private void addParticipateToRoom(Room room, SparkUser sparkUser) {
+        RoomParticipate roomParticipate = RoomParticipate.builder().room(room).sparkUser(sparkUser).isOwner(false).build();
+        roomParticipateRepository.save(roomParticipate);
+        room.assignRoomParticipate(roomParticipate);
+        redisTemplate.opsForHash().increment(ROOM_COUNT_KEY, room.getRoomId().toString(), 1);
+    }
+
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/response/RoomListResponse.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/response/RoomListResponse.java
@@ -1,0 +1,25 @@
+package mutsa.yewon.talksparkbe.domain.game.service.response;
+
+import lombok.Builder;
+import lombok.Data;
+import mutsa.yewon.talksparkbe.domain.game.entity.Room;
+
+@Data
+@Builder
+public class RoomListResponse {
+
+    private Long roomId;
+    private String roomName;
+    private String hostName;
+    private int currentPeople;
+    private int maxPeople;
+
+    public static RoomListResponse from(Room room) {
+        return RoomListResponse.builder()
+                .roomId(room.getRoomId())
+                .roomName(room.getRoomName())
+                .maxPeople(room.getMaxPeople())
+                .build();
+    }
+
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/entity/SparkUser.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/entity/SparkUser.java
@@ -4,10 +4,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SparkUser {
 
     @Id
@@ -17,5 +21,11 @@ public class SparkUser {
     private String name;
 
     private String kakaoId;
+
+    @Builder
+    private SparkUser(String name, String kakaoId) {
+        this.name = name;
+        this.kakaoId = kakaoId;
+    }
 
 }

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/repository/SparkUserRepository.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/repository/SparkUserRepository.java
@@ -1,0 +1,7 @@
+package mutsa.yewon.talksparkbe.domain.sparkUser.repository;
+
+import mutsa.yewon.talksparkbe.domain.sparkUser.entity.SparkUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SparkUserRepository extends JpaRepository<SparkUser, Long> {
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/global/config/WebSecurityConfig.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/global/config/WebSecurityConfig.java
@@ -1,0 +1,35 @@
+package mutsa.yewon.talksparkbe.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(CsrfConfigurer<HttpSecurity>::disable)
+                .formLogin(FormLoginConfigurer<HttpSecurity>::disable)
+                .httpBasic(HttpBasicConfigurer<HttpSecurity>::disable)
+                .headers(it -> it.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .sessionManagement(it ->
+                        it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(
+                        authorize -> authorize
+                                .anyRequest().permitAll()
+                );
+        return http.build();
+    }
+
+}


### PR DESCRIPTION
## 👋 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closes #3 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. 테스트 혹은 기능에 대한 사진이 첨부되면 좋습니다!-->

TalkSpark의 방에는 최대인원수가 있습니다. 현재인원이 최대인원수와 같으면 더이상 들어갈 수 없어야 합니다. 현재 들어간 인원들에 대한 정보를 DB에서만 얻어오고 동시성에 대한 조치가 없다면, DB 접근 시간으로 인해 최대인원수보다 많은 사람이 방에 들어간 상태가 생길 수 있습니다. 따라서 현재인원수 정보는 빠른 In-Memory DB인 Redis에 저장하고, Redisson 락을 적용해 한 시점에 한 클라이언트만이 현재인원수 정보를 변경하고 입장할 수 있게 했습니다!

<details>
<summary>테스트 사진</summary>
<img width="481" alt="1" src="https://github.com/user-attachments/assets/5cda62c8-3a27-4277-a4de-56f14e697a67"> <br> 테스트용 유저 3명을 만들었습니다. <br>

<img width="434" alt="2" src="https://github.com/user-attachments/assets/b484d16d-a0ad-4d43-8a3f-f626769515bc"> <br> 1번 유저가 방장인 방 하나를 만듭니다. 최대인원은 2명입니다. <br>

<img width="392" alt="3" src="https://github.com/user-attachments/assets/dad2a257-4378-4b0a-9fc2-61ad5de7ed00"> <br> 방 목록에 현재인원이 1인 방이 보입니다. <br>

<img width="430" alt="4" src="https://github.com/user-attachments/assets/5d35d46c-293d-48fe-baa7-0773af1cfdc9"> <br> 방 목록에 현재인원이 1인 방이 보입니다. <br>

<img width="430" alt="4" src="https://github.com/user-attachments/assets/be58869b-1b8b-4349-a3e4-428676a5dd98"> <br> 한 명이 더 들어갈 수 있음을 알고 2번 유저가 들어갑니다. <br>

<img width="297" alt="5" src="https://github.com/user-attachments/assets/5a3bf8fb-632d-475e-af6d-9dd511e88401"> <br> 레디스에서 1번 방의 현재인원수가 2명임을 확인 가능합니다. <br>

<img width="430" alt="6" src="https://github.com/user-attachments/assets/3edd2f3d-d7ed-4a21-8b4c-da63ba8871aa"> <br> 최대인원이 2명이기 때문에 한 명 더 들어갈 수 없습니다. <br>
</details>

## 📋 PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 To Reviewers
<!-- 이번 수정 관련 전달사항이나 의논할 점이 있다면, 전달할 사람을 @{github id}로 멘션하고 작성해주세요! -->
<!-- 특이사항이 없다면 비워두셔도 좋습니다. -->
@psb3707
- 작업한 API를 테스트하기 위해 시큐리티 설정에서 모든 엔드포인트를 permitAll()로 해놨습니다. 해당 임시 설정 파일은 src/main/java/mutsa/yewon/talksparkbe/global/config/WebSecurityConfig.java 입니다. 저 위치에 시큐리티 설정 파일을 둬도 괜찮을까요?
- SparkUser에 기본 생성자 protect 및 빌더 적용을 안 해놨어서 지금 해놨습니다!

@psb3707 @lee-youn 
Redis를 사용하기 때문에, 로컬에서 사용하실 때에도 Redis를 설치하고 켜놓으셔야 프로젝트 실행이 정상적으로 됩니다.
- 윈도우에서 Redis 설치 : https://ittrue.tistory.com/318
- 맥에서 Redis 설치 : https://herojoon-dev.tistory.com/170

---

이슈 생성 시점에는 생성 대기 화면을 위한 백엔드 구현까지 하려 했으나, 전달사항이 꽤 있어 일단 여기까지 하고 PR 작성했습니다...