### PR TITLE
Refactor: #9 JWT 토큰 생성 키 숨김 및 DTO 변환 static 메서드 추가

### DIFF
--- a/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/controller/SparkUserController.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/controller/SparkUserController.java
@@ -16,6 +16,7 @@ import java.util.Map;
 public class SparkUserController {
 
     private final SparkUserService sparkUserService;
+    private final JWTUtil jwtUtil;
 
     @GetMapping("/api/member/kakao")
     public Map<String, Object> login(String accessToken) {
@@ -23,22 +24,20 @@ public class SparkUserController {
 
         Map<String, Object> claims = kakaoUser.getClaims();
 
-        String JWTAccessToken = JWTUtil.generateToken(claims, 10);
-        String JWTRefreshToken = JWTUtil.generateToken(claims, 60 * 24);
+        String JWTAccessToken = jwtUtil.generateToken(claims, 10);
+        String JWTRefreshToken = jwtUtil.generateToken(claims, 60 * 24);
 
         claims.put("accessToken", JWTAccessToken);
         claims.put("refreshToken", JWTRefreshToken);
-
-        log.info(claims);
 
         return claims;
     }
 
     @GetMapping("/api/member/refresh")
     public Map<String, Object> refresh(String refreshToken) {
-        Map<String, Object> claims = JWTUtil.validateToken(refreshToken);
+        Map<String, Object> claims = jwtUtil.validateToken(refreshToken);
 
-        String accessToken = JWTUtil.generateToken(claims, 10);
+        String accessToken = jwtUtil.generateToken(claims, 10);
 
         return Map.of("accessToken", accessToken, "refreshToken", refreshToken);
     }

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/dto/SparkUserDTO.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/dto/SparkUserDTO.java
@@ -1,5 +1,6 @@
 package mutsa.yewon.talksparkbe.domain.sparkUser.dto;
 
+import mutsa.yewon.talksparkbe.domain.sparkUser.entity.SparkUser;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -24,6 +25,11 @@ public class SparkUserDTO extends User {
         this.name = name;
         this.password = password;
         this.roleNames = roleNames;
+    }
+
+    public static SparkUserDTO from(SparkUser sparkUser) {
+        return new SparkUserDTO(sparkUser.getKakaoId(), sparkUser.getName(), sparkUser.getPassword(),
+                sparkUser.getRoles().stream().map(role -> role.name()).toList());
     }
 
     public Map<String, Object> getClaims() {

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/service/SparkUserServiceImpl.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/service/SparkUserServiceImpl.java
@@ -40,7 +40,7 @@ public class SparkUserServiceImpl implements SparkUserService {
         Optional<SparkUser> sparkUser = sparkUserRepository.findByKakaoId(kakaoId);
 
         if(sparkUser.isPresent()) {
-            SparkUserDTO sparkUserDTO = entityToDTO(sparkUser.get());
+            SparkUserDTO sparkUserDTO = SparkUserDTO.from(sparkUser.get());
             return sparkUserDTO;
         }
 
@@ -48,7 +48,7 @@ public class SparkUserServiceImpl implements SparkUserService {
 
         sparkUserRepository.save(createdUser);
 
-        SparkUserDTO sparkUserDTO = entityToDTO(createdUser);
+        SparkUserDTO sparkUserDTO = SparkUserDTO.from(createdUser);
 
         return sparkUserDTO;
     }
@@ -66,18 +66,14 @@ public class SparkUserServiceImpl implements SparkUserService {
                 .bodyToMono(LinkedHashMap.class)
                 .block();
 
-        log.info(response);
 
         String kakaoId = String.valueOf(response.get("id"));
-        log.info(kakaoId);
 
         LinkedHashMap<String, String> properties = (LinkedHashMap<String, String>) response.get("properties");
 
-        log.info(properties);
 
         String name = properties.get("nickname");
 
-        log.info(name);
 
         return Map.of("kakaoId", kakaoId, "name", name);
     }

--- a/src/main/java/mutsa/yewon/talksparkbe/global/config/WebSecurityConfig.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/global/config/WebSecurityConfig.java
@@ -1,6 +1,8 @@
 package mutsa.yewon.talksparkbe.global.config;
 
+import lombok.RequiredArgsConstructor;
 import mutsa.yewon.talksparkbe.global.security.JWTCheckFilter;
+import mutsa.yewon.talksparkbe.global.util.JWTUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -21,7 +23,10 @@ import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class WebSecurityConfig {
+
+    private final JWTUtil jwtUtil;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -34,11 +39,11 @@ public class WebSecurityConfig {
                 .sessionManagement(it ->
                         it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
-                .addFilterBefore(new JWTCheckFilter(), UsernamePasswordAuthenticationFilter.class );
-//                .authorizeHttpRequests(
-//                        authorize -> authorize
-//                                .anyRequest().permitAll()
-//                );
+//                .addFilterBefore(jwtCheckFilter(), UsernamePasswordAuthenticationFilter.class );
+                .authorizeHttpRequests(
+                        authorize -> authorize
+                                .anyRequest().permitAll()
+                );
         return http.build();
     }
 
@@ -61,6 +66,11 @@ public class WebSecurityConfig {
         source.registerCorsConfiguration("/**", configuration);
 
         return source;
+    }
+
+    @Bean
+    public JWTCheckFilter jwtCheckFilter() {
+        return new JWTCheckFilter(jwtUtil);
     }
 
 }

--- a/src/main/java/mutsa/yewon/talksparkbe/global/security/JWTCheckFilter.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/global/security/JWTCheckFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import mutsa.yewon.talksparkbe.domain.sparkUser.dto.SparkUserDTO;
 import mutsa.yewon.talksparkbe.global.exception.CustomTalkSparkException;
@@ -21,7 +22,10 @@ import java.util.List;
 import java.util.Map;
 
 @Log4j2
+@RequiredArgsConstructor
 public class JWTCheckFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
 
 
     @Override
@@ -48,7 +52,7 @@ public class JWTCheckFilter extends OncePerRequestFilter {
 
         try {
             String accessToken = authorization.substring(7);
-            Map<String, Object> claims = JWTUtil.validateToken(accessToken);
+            Map<String, Object> claims = jwtUtil.validateToken(accessToken);
 
             String kakaoId = (String) claims.get("kakaoId");
             String name = (String) claims.get("name");

--- a/src/main/java/mutsa/yewon/talksparkbe/global/util/JWTUtil.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/global/util/JWTUtil.java
@@ -2,9 +2,13 @@ package mutsa.yewon.talksparkbe.global.util;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import mutsa.yewon.talksparkbe.global.exception.CustomTalkSparkException;
 import mutsa.yewon.talksparkbe.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
 import java.io.IOException;
@@ -13,17 +17,20 @@ import java.util.Date;
 import java.util.Map;
 
 @Log4j2
+@Component
+@RequiredArgsConstructor
 public class JWTUtil {
 
 
-    private static String key = "1234567890123456789012345678901234567890"; // 키 값으 최소 30자 이상
+    @Value("${secret.key}")
+    private String jwtKey;
 
-    public static String generateToken(Map<String, Object> claims, int min) {
+    public String generateToken(Map<String, Object> claims, int min) {
 
         SecretKey key = null;
 
         try {
-            key = Keys.hmacShaKeyFor(JWTUtil.key.getBytes("UTF-8"));
+            key = Keys.hmacShaKeyFor(jwtKey.getBytes("UTF-8"));
 
         }catch (Exception e) {
             throw new RuntimeException(e.getMessage());
@@ -40,12 +47,12 @@ public class JWTUtil {
         return jwt;
     }
 
-    public static Map<String, Object> validateToken(String token) {
+    public Map<String, Object> validateToken(String token) {
         log.info("validation token");
         Map<String, Object> claims = null;
 
         try {
-            SecretKey key = Keys.hmacShaKeyFor(JWTUtil.key.getBytes("UTF-8"));
+            SecretKey key = Keys.hmacShaKeyFor(jwtKey.getBytes("UTF-8"));
 
             claims = Jwts.parserBuilder()
                     .setSigningKey(key)

--- a/src/test/java/mutsa/yewon/talksparkbe/global/util/JWTUtilTest.java
+++ b/src/test/java/mutsa/yewon/talksparkbe/global/util/JWTUtilTest.java
@@ -22,6 +22,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 class JWTUtilTest {
 
     @Autowired
+    private JWTUtil jwtUtil;
+
+    @Autowired
     private ObjectMapper objectMapper;
 
     @Autowired
@@ -40,7 +43,7 @@ class JWTUtilTest {
         String accessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJwYXNzd29yZCI6IiQyYSQxMCRJWEo3cHlFY2pQLmEzUldEWFlZaFgubnk5V2JPaGdMbVpJcURHSjVrOUlLZXplTmxiNU5wYSIsIm5hbWUiOiLrsJXsirnrspQiLCJrYWthb0lkIjoiMzc3Njg4NTE5MiIsInJvbGVOYW1lcyI6WyJVU0VSIl0sImlhdCI6MTczMDg5Njg5NiwiZXhwIjoxNzMwODk3NDk2fQ.0qSUBzb6Mg4LEKuApmoJLyohdKYaTzNHr-IAkbZ_6zE";
 
         CustomTalkSparkException ex = assertThrows(CustomTalkSparkException.class, () -> {
-            JWTUtil.validateToken(accessToken);
+            jwtUtil.validateToken(accessToken);
         });
 
         String expectedMessage = "만료된 토큰 입니다.";


### PR DESCRIPTION
## 👋 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closes #9 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. 테스트 혹은 기능에 대한 사진이 첨부되면 좋습니다!-->

1. 기존애 노출되어 있던 JWT 토큰 생성 키를 secret.yaml 파일로 옮기고 JWTUtil 클래스를 컴포넌트로 등록한 뒤 @Value 어노테이션을 통해서 값을 불러오도록 수정하였습니다.
2. 기존 entityToDTO() 메서드를 SparkUserDTO 내 static 메서드로 정의하고 사용할 수 있도록 수정하였습니다.

## 📋 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 To Reviewers
<!-- 이번 수정 관련 전달사항이나 의논할 점이 있다면, 전달할 사람을 @{github id}로 멘션하고 작성해주세요! -->
<!-- 특이사항이 없다면 비워두셔도 좋습니다. -->
