### PR TITLE
Feat:#36 회원 탈퇴 API추가 및 Swagger UI에 명시 완료

### DIFF
--- a/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/SparkUserControllerDocs.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/SparkUserControllerDocs.java
@@ -2,12 +2,15 @@ package mutsa.yewon.talksparkbe.domain.sparkUser;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import mutsa.yewon.talksparkbe.domain.sparkUser.dto.SparkUserDTO;
+import mutsa.yewon.talksparkbe.global.dto.ResponseDTO;
 import mutsa.yewon.talksparkbe.global.exception.ErrorCode;
 import mutsa.yewon.talksparkbe.global.swagger.ApiErrorCodes;
+import org.springframework.http.ResponseEntity;
 
 import java.util.Map;
 
@@ -37,5 +40,23 @@ public interface SparkUserControllerDocs {
                         "refreshToken" : "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJwYXNzd29yZCI6IiQyYSQxMCRiZlhBbzhhN2FJQjNYa1p1QndFMDJlRlJway9sTk5uNkNMOEtHc3VIVC5iUThWcUxpYS9xYSIsIm5hbWUiOiLrsJXsirnrspQiLCJrYWthb0lkIjoiMzc3Njg4NTE5MiIsInJvbGVOYW1lcyI6WyJVU0VSIl0sInNwYXJrVXNlcklkIjoxLCJpYXQiOjE3MzE2NDg1OTcsImV4cCI6MTczMTczNDk5N30.e8psA40ogHbewqqkrtrkRRYoLAR_0XC51y8Z6uyhNY0"
                     }
                     """)))
+
     Map<String, Object> refresh(String refreshToken);
+
+    @Operation(summary = "회원 탈퇴", description = "AccessToken을 이용해 회원 특정 후 회원 정보를 삭제하는 API")
+    @ApiErrorCodes({ErrorCode.JWT_TOKEN_EXPIRED, ErrorCode.TOKEN_REQUIRED, ErrorCode.INVALID_JWT_TOKEN})
+    @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공",
+    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseDTO.class),
+    examples = {
+            @ExampleObject(
+                    value = """
+                            {
+                                "status": 200,
+                                "message": "회원정보가 삭제되었습니다.",
+                                "data": 1
+                            }
+                            """
+            )
+    }))
+    ResponseEntity<?> accountDelete(String accessToken);
 }

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/controller/SparkUserController.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/controller/SparkUserController.java
@@ -5,11 +5,11 @@ import lombok.extern.log4j.Log4j2;
 import mutsa.yewon.talksparkbe.domain.sparkUser.SparkUserControllerDocs;
 import mutsa.yewon.talksparkbe.domain.sparkUser.dto.SparkUserDTO;
 import mutsa.yewon.talksparkbe.domain.sparkUser.service.SparkUserService;
+import mutsa.yewon.talksparkbe.global.dto.ResponseDTO;
 import mutsa.yewon.talksparkbe.global.util.JWTUtil;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import mutsa.yewon.talksparkbe.global.util.SecurityUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -19,6 +19,7 @@ import java.util.Map;
 public class SparkUserController implements SparkUserControllerDocs {
 
     private final SparkUserService sparkUserService;
+
     private final JWTUtil jwtUtil;
 
     @PostMapping("/api/member/kakao")
@@ -46,5 +47,19 @@ public class SparkUserController implements SparkUserControllerDocs {
         String accessToken = jwtUtil.generateToken(claims, 10);
 
         return Map.of("accessToken", accessToken, "refreshToken", refreshToken);
+    }
+
+    @DeleteMapping("/api/member/leave")
+    public ResponseEntity<?> accountDelete(String accessToken) {
+        // jwtfilter를 거치지 않기 때문에 등록 x
+
+        Map<String, Object> claims = jwtUtil.validateToken(accessToken);
+
+        Number sparkUserIdNumber = (Number) claims.get("sparkUserId");
+        Long sparkUserId = (sparkUserIdNumber != null) ? sparkUserIdNumber.longValue() : null;
+
+        Long deletedUserId = sparkUserService.deleteAccount(sparkUserId);
+
+        return ResponseEntity.ok().body(ResponseDTO.ok("회원정보가 삭제되었습니다.", deletedUserId));
     }
 }

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/service/SparkUserService.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/service/SparkUserService.java
@@ -10,6 +10,7 @@ public interface SparkUserService {
 
     SparkUserDTO getKakaoUser(String accessToken);
     SparkUserDTO generateTestUser(String name);
+    Long deleteAccount(Long sparkUserId);
 
 //    default SparkUserDTO entityToDTO(SparkUser sparkUser) {
 //        return new SparkUserDTO(sparkUser.getKakaoId(), sparkUser.getName(), sparkUser.getPassword(),

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/service/SparkUserServiceImpl.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/sparkUser/service/SparkUserServiceImpl.java
@@ -8,6 +8,7 @@ import mutsa.yewon.talksparkbe.domain.sparkUser.entity.SparkUserRole;
 import mutsa.yewon.talksparkbe.domain.sparkUser.repository.SparkUserRepository;
 import mutsa.yewon.talksparkbe.global.exception.CustomTalkSparkException;
 import mutsa.yewon.talksparkbe.global.exception.ErrorCode;
+import mutsa.yewon.talksparkbe.global.util.SecurityUtil;
 import org.springframework.http.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,7 @@ public class SparkUserServiceImpl implements SparkUserService {
     private final SparkUserRepository sparkUserRepository;
 
     private final PasswordEncoder passwordEncoder;
+    private final SecurityUtil securityUtil;
 
     @Override
     public SparkUserDTO getKakaoUser(String accessToken) {
@@ -123,6 +125,20 @@ public class SparkUserServiceImpl implements SparkUserService {
         SparkUser createdUser = makeSparkUser(String.valueOf(randomNumber), name);
         sparkUserRepository.save(createdUser);
         return SparkUserDTO.from(createdUser);
+    }
+
+    @Override
+    @Transactional
+    public Long deleteAccount(Long sparkUserId) {
+
+        sparkUserRepository.findById(sparkUserId)
+                        .orElseThrow(()-> new CustomTalkSparkException(ErrorCode.USER_NOT_EXIST));
+
+
+
+        sparkUserRepository.deleteById(sparkUserId);
+
+        return sparkUserId;
     }
 
 }

--- a/src/main/java/mutsa/yewon/talksparkbe/global/util/SecurityUtil.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/global/util/SecurityUtil.java
@@ -1,14 +1,17 @@
 package mutsa.yewon.talksparkbe.global.util;
 
+import lombok.extern.log4j.Log4j2;
 import mutsa.yewon.talksparkbe.domain.sparkUser.dto.SparkUserDTO;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
+@Log4j2
 public class SecurityUtil {
 
     public Long getLoggedInUserId() {
+
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         SparkUserDTO sparkUser = (SparkUserDTO) authentication.getPrincipal();


### PR DESCRIPTION
## 👋 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closes #36 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. 테스트 혹은 기능에 대한 사진이 첨부되면 좋습니다!-->


## 📋 PR 유형
어떤 변경 사항이 있나요?

1. 회원 탈퇴 API를 추가하였습니다. 클라이언트로부터 AccessToken을 전달받아 회원을 특정하고 DB에서 삭제하는 방식으로 구현하였습니다. 

2. Swagger UI에도 해당 API에 대한 정보를 명시하였습니다. 

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 To Reviewers
<!-- 이번 수정 관련 전달사항이나 의논할 점이 있다면, 전달할 사람을 @{github id}로 멘션하고 작성해주세요! -->
<!-- 특이사항이 없다면 비워두셔도 좋습니다. -->
