### PR TITLE
Refactor/#53 보관된 명함 조회 시 팀 이름과 즐겨찾기 여부 정보 반환하도록 수정

### DIFF
--- a/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/CardHolderControllerDocs.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/CardHolderControllerDocs.java
@@ -213,4 +213,38 @@ public interface CardHolderControllerDocs {
                     }))
     })
     ResponseEntity<?> deleteCardHolder(@PathVariable Long cardHolderId);
+
+    @Operation(summary = "명함 검색", description = "팀 또는 사용자 이름을 기준으로 검색하는 API")
+    @ApiErrorCodes({ErrorCode.NO_MATCHING_CARDHOLDER, ErrorCode.JWT_TOKEN_EXPIRED, ErrorCode.TOKEN_REQUIRED, ErrorCode.INTERNAL_SERVER_ERROR})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "명함 검색 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseDTO.class),examples = {
+                    @ExampleObject(
+                            value = """
+                                    {
+                                        "status": 200,
+                                        "message": "팀 또는 사용자의 이름에 해당하는 명함들입니다.",
+                                        "data": {
+                                            "numOfCards": 1,
+                                            "searchType": "멋사우주최강",
+                                            "cardHolders": [
+                                                {
+                                                    "cardHolderId": 2,
+                                                    "cardHolderName": "멋사우주최강",
+                                                    "numOfTeammates": 2,
+                                                    "teamNames": [
+                                                        "박승범",
+                                                        "박승범"
+                                                    ],
+                                                    "bookMark": false,
+                                                    "storedAt": "2024-12-26T14:53:30.626356"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                    """
+                    )
+            }))
+    })
+    ResponseEntity<?> getCardHoldersByName(@RequestParam String name);
 }

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/CardHolderControllerDocs.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/CardHolderControllerDocs.java
@@ -80,19 +80,7 @@ public interface CardHolderControllerDocs {
                                         "message": "모든 팀원들의 명함을 조회합니다.",
                                         "data": [
                                             {
-                                                "storedCardId": 9,
-                                                "name": "박승범",
-                                                "age": 24,
-                                                "major": "컴퓨터공학",
-                                                "mbti": "ISTJ",
-                                                "hobby": "코딩",
-                                                "lookAlike": "너구리",
-                                                "slogan": "코딩하는 너구리",
-                                                "tmi": "TalkSparkIsFun!!!",
-                                                "cardThema": "YELLOW"
-                                            },
-                                            {
-                                                "storedCardId": 10,
+                                                "storedCardId": 2,
                                                 "name": "박승범",
                                                 "age": 24,
                                                 "major": "컴퓨터공학과",
@@ -100,8 +88,24 @@ public interface CardHolderControllerDocs {
                                                 "hobby": "코딩",
                                                 "lookAlike": "너구리",
                                                 "slogan": "개발자가 되",
-                                                "tmi": "TalkSpark",
-                                                "cardThema": "MINT"
+                                                "tmi": "TalkSpark!!!",
+                                                "cardThema": "PINK",
+                                                "bookMark": false,
+                                                "cardHolderName": "멋사우주최강"
+                                            },
+                                            {
+                                                "storedCardId": 3,
+                                                "name": "박승범",
+                                                "age": 24,
+                                                "major": "컴퓨터공학과",
+                                                "mbti": "ISTJ",
+                                                "hobby": "코딩",
+                                                "lookAlike": "너구리",
+                                                "slogan": "개발자가 되",
+                                                "tmi": "TalkSpark!!!",
+                                                "cardThema": "MINT",
+                                                "bookMark": false,
+                                                "cardHolderName": "멋사우주최강"
                                             }
                                         ]
                                     }

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/controller/CardHolderController.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/controller/CardHolderController.java
@@ -68,4 +68,11 @@ public class CardHolderController implements CardHolderControllerDocs {
 
         return ResponseEntity.ok(ResponseDTO.ok("보관된 명함을 삭제합니다", response));
     }
+
+    @GetMapping("/api/storedCards/search")
+    public ResponseEntity<?> getCardHoldersByName(@RequestParam String name) {
+        CardHolderListDTO cardHolderByName = storedCardService.getCardHolderByName(name);
+
+        return ResponseEntity.ok(ResponseDTO.ok("팀 또는 사용자의 이름에 해당하는 명함들입니다.", cardHolderByName));
+    }
 }

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/dto/CardHolderListDTO.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/dto/CardHolderListDTO.java
@@ -14,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor
 public class CardHolderListDTO {
 
-    private Long numOfCards;
+    private int numOfCards;
 
     private String searchType;
 

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/dto/StoredCardDTO.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/dto/StoredCardDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import mutsa.yewon.talksparkbe.domain.card.entity.CardThema;
+import mutsa.yewon.talksparkbe.domain.cardHolder.entity.CardHolder;
 import mutsa.yewon.talksparkbe.domain.cardHolder.entity.StoredCard;
 
 @Data
@@ -33,7 +34,11 @@ public class StoredCardDTO {
 
     private CardThema cardThema;
 
-    public static StoredCardDTO entityToDTO(StoredCard storedCard) {
+    private boolean bookMark;
+
+    private String cardHolderName;
+
+    public static StoredCardDTO entityToDTO(StoredCard storedCard, CardHolder cardHolder) {
         return StoredCardDTO.builder()
                 .storedCardId(storedCard.getId())
                 .name(storedCard.getName())
@@ -45,6 +50,8 @@ public class StoredCardDTO {
                 .slogan(storedCard.getSlogan())
                 .tmi(storedCard.getTmi())
                 .cardThema(storedCard.getCardThema())
+                .bookMark(cardHolder.isBookMark())
+                .cardHolderName(cardHolder.getName())
                 .build();
     }
 }

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/entity/CardHolder.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/entity/CardHolder.java
@@ -42,6 +42,7 @@ public class CardHolder {
 
     @Builder.Default
     @OneToMany(mappedBy = "cardHolder", cascade = CascadeType.ALL)
+    @BatchSize(size = 8)
     private List<StoredCard> storedCards = new ArrayList<>(); // 개별 명함인 경우 1개, 팀별 명함 모음인 경우 팀원 수 만큼
 
     @CreatedDate

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/repository/CardHolderRepository.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/repository/CardHolderRepository.java
@@ -18,5 +18,8 @@ public interface CardHolderRepository extends JpaRepository<CardHolder, Long> {
     @Query("select c from CardHolder c where c.sparkUser.id = :sparkUserId and c.bookMark = true")
     List<CardHolder> getCardHolderByBookMark(@Param("sparkUserId") Long sparkUserId);
 
-    Long countBySparkUserId(Long sparkUserId);
+    int countBySparkUserId(Long sparkUserId);
+
+    @Query("select c from CardHolder c where c.name = :name")
+    List<CardHolder> getCardHoldersByName(@Param("name") String name);
 }

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/service/StoredCardService.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/cardHolder/service/StoredCardService.java
@@ -18,4 +18,5 @@ public interface StoredCardService {
     CardHolderListDTO getCardHolderDTOs(String searchType, Long sparkUserId);
     Map<String, Long> bookMarkCard(Long cardHolderId);
     Map<String, Long> deleteCardHolder(Long cardHolderId);
+    CardHolderListDTO getCardHolderByName(String searchType);
 }

--- a/src/main/java/mutsa/yewon/talksparkbe/global/config/SwaggerConfig.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/global/config/SwaggerConfig.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 @OpenAPIDefinition(
     servers = {
             @Server(url = "http://localhost:8080", description = "로컬 테스트 서버"),
+            @Server(url = "https://talkspark-dev-api.p-e.kr", description = "배포된 개발 서버"),
     }
 )
 @Configuration

--- a/src/main/java/mutsa/yewon/talksparkbe/global/exception/ErrorCode.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/global/exception/ErrorCode.java
@@ -25,7 +25,9 @@ public enum ErrorCode {
     INVALID_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 형식입니다."),
     GUESTBOOK_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "방명록 방을 찾지 못했습니다."),
     CARDHOLDER_NOT_EXIST(HttpStatus.NOT_FOUND, "해당하는 명함은 저장된 이력이 없습니다."),
-    NO_BOOKMARKED_CONTENT(HttpStatus.NOT_FOUND, "즐겨찾기 된 명함이 없습니다.");
+    NO_BOOKMARKED_CONTENT(HttpStatus.NOT_FOUND, "즐겨찾기 된 명함이 없습니다."),
+    NO_MATCHING_CARDHOLDER(HttpStatus.NOT_FOUND, "해당하는 이름의 명함이 존재하지 않습니다.");
+
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 👋 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closes #53 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. 테스트 혹은 기능에 대한 사진이 첨부되면 좋습니다!-->

1. 보관된 명함 개별 조회 시 반환되는 데이터에 해당 명함에 대한 즐겨찾기 여부와 소속 팀이름(개별 명함인 경우 명함 주인 이름) 을 추가하여 반환하도록 수정하였습니다.

2. Swagger 에 보관된 명함 개별 조회 성공 시 반환되는 예시 반환값을 추가했습니다.

3. Swagger 설정에 배포된 서버 url 명시하였습니다.

## 📋 PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 To Reviewers
<!-- 이번 수정 관련 전달사항이나 의논할 점이 있다면, 전달할 사람을 @{github id}로 멘션하고 작성해주세요! -->
<!-- 특이사항이 없다면 비워두셔도 좋습니다. -->
