### PR TITLE
Feat: #54 방명록 초기 데이터 생성 구현

### DIFF
--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/entity/Room.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/entity/Room.java
@@ -48,7 +48,6 @@ public class Room {
         this.roomName = roomName;
         this.maxPeople = maxPeople;
         this.difficulty = difficulty;
-        this.guestBookRoom = new GuestBookRoom(this);
     }
 
     public void addRoomParticipate(RoomParticipate roomParticipate) {

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/guestBook/GuestBookControllerDocs.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/guestBook/GuestBookControllerDocs.java
@@ -18,6 +18,7 @@ import mutsa.yewon.talksparkbe.global.exception.ErrorCode;
 import mutsa.yewon.talksparkbe.global.swagger.ApiErrorCodes;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -163,6 +164,7 @@ public interface GuestBookControllerDocs {
     ResponseEntity<?> getGuestBookList(@PathVariable("roomId") Long roomId);
 
     @Operation(summary = "방 방명록 즐겨찾기 추가", description = "방명록 보관함에서 방명록 방 즐겨찾기를 추가하는 API")
+    @ApiErrorCodes({ErrorCode.USER_NOT_EXIST, ErrorCode.JWT_TOKEN_EXPIRED, ErrorCode.TOKEN_REQUIRED, ErrorCode.INVALID_JWT_TOKEN})
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "방명록 방 즐겨찾기 성공",
                     content = @Content(mediaType = "application/json",
@@ -180,4 +182,24 @@ public interface GuestBookControllerDocs {
                             }))
     })
     ResponseEntity<?> UpdateGuestBookRoomFavorites(@PathVariable("roomId") Long roomId);
+
+    @Operation(summary = "방명록 데이터 생성", description = "게임 종료 후 방명록 관련 테이블를 생성하는 API")
+    @ApiErrorCodes({ErrorCode.USER_NOT_EXIST, ErrorCode.JWT_TOKEN_EXPIRED, ErrorCode.TOKEN_REQUIRED, ErrorCode.INVALID_JWT_TOKEN})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "방명록 데이터 생성 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseDTO.class),
+                            examples = {
+                                    @ExampleObject(
+                                            value = """
+                                                    {
+                                                        "status": 201,
+                                                        "message": "방명록 초기 데이터 생성하였습니다.",
+                                                        "data": null
+                                                    }
+                                                    """
+                                    )
+                            }))
+    })
+    ResponseEntity<?> postGuestBook(@RequestParam(required = true) Long roomId);
 }

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/guestBook/controller/GuestBookController.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/guestBook/controller/GuestBookController.java
@@ -36,6 +36,18 @@ public class GuestBookController implements GuestBookControllerDocs {
 
     //TODO: RuntimeException("User not found") 에러코드로 리펙토링
 
+    @PostMapping("/create")
+    public ResponseEntity<?> postGuestBook(@RequestParam(required = true) Long roomId) {
+
+        try {
+            guestBookService.createGuestBookData(roomId);
+            ResponseDTO<?> responseDTO = ResponseDTO.created("방명록 초기 데이터 생성하였습니다.");
+            return ResponseEntity.status(201).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            throw new CustomTalkSparkException(ErrorCode.INVALID_FORMAT);
+        }
+    }
+
     @PostMapping("/{roomId}")
     public ResponseEntity<?> postGuestBook(@PathVariable("roomId") Long roomId,
                                            @RequestParam(required = false) boolean anonymity,

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/guestBook/service/GuestBookRoomService.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/guestBook/service/GuestBookRoomService.java
@@ -113,10 +113,7 @@ public class GuestBookRoomService {
 
     @Transactional
     public void deleteGuestBookRoom(Long sparkUserId, Long roomId) {
-        Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new CustomTalkSparkException(ErrorCode.ROOM_NOT_FOUND));
-
-        GuestBookRoom guestBookRoom = room.getGuestBookRoom();
+        GuestBookRoom guestBookRoom = guestBookRoomRepository.findByRoomId(roomId);
 
         GuestBookRoomSparkUser sparkUserToDelete = guestBookRoom.getGuestBookRoomSparkUsers().stream()
                 .filter(deleteSparkUser -> deleteSparkUser.getSparkUser().getId().equals(sparkUserId))


### PR DESCRIPTION
## 👋 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. 테스트 혹은 기능에 대한 사진이 첨부되면 좋습니다!-->
방이 생성될 때 방명록 데이터가 같이 생성되는 것이 아니라,
프론트에서 게임 종료 후 방명록으로 넘어가기 전 방명록 초기 데이터 생성 요청 api를 보내면 그 때 관련 테이터들이 생성되도록 로직을 변경하였습니다.
++swagger에도 추가하였습니다.

방명록 생성과 관련하여 로직을 테스트 하는 과정은 다음과 같습니다.
1. [사용자 명함을 생성한다]
2. 방을 생성한다
3. 게임에 참여한다
4. 해당 roomId에 대하여 방명록 초기 데이터 생성한다.
5. 방명록을 작성한다

=> 방에 참여하는 사용자를 기반으로 데이터를 생성하기에 room.roomParticipate에 없는 사용자라면 제대로 로직이 작동하지 않을 수 있습니다..

## 📋 PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 To Reviewers
<!-- 이번 수정 관련 전달사항이나 의논할 점이 있다면, 전달할 사람을 @{github id}로 멘션하고 작성해주세요! -->
<!-- 특이사항이 없다면 비워두셔도 좋습니다. -->
