### PR TITLE
Chore: #99 참가자 중복 참가 가능하게 수정

### DIFF
--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/RoomController.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/RoomController.java
@@ -29,10 +29,16 @@ public class RoomController {
     private final SecurityUtil securityUtil;
 
     @PostMapping
-    public ResponseEntity<RoomCreateResponse> roomCreate(@RequestBody RoomCreateRequest roomCreateRequest) {
+    public ResponseEntity<RoomCreateResponse> roomCreate(@RequestBody RoomCreateRequest roomCreateRequest,
+                                                         @RequestHeader("Authorization") String token) {
+        String jwt = token.replace("Bearer ", "");
+        Map<String, Object> claims = jwtUtil.validateToken(jwt);
+        String kakaoId = (String) claims.get("kakaoId");
+        SparkUser sparkUser = sparkUserRepository.findByKakaoId(kakaoId).orElseThrow(() -> new RuntimeException("유저 못찾음"));
+
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(
-                        RoomCreateResponse.from(roomService.createRoom(roomCreateRequest))
+                        RoomCreateResponse.from(roomService.createRoom(roomCreateRequest, sparkUser.getId()))
                 );
     }
 

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/entity/Room.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/entity/Room.java
@@ -29,6 +29,8 @@ public class Room {
 
     private int difficulty;
 
+    private Long hostId;
+
     private boolean isStarted = false;
     private boolean isFinished = false;
 
@@ -42,10 +44,11 @@ public class Room {
     private GuestBookRoom guestBookRoom;
 
     @Builder
-    private Room(String roomName, int maxPeople, int difficulty) {
+    private Room(String roomName, int maxPeople, int difficulty, Long hostId) {
         this.roomName = roomName;
         this.maxPeople = maxPeople;
         this.difficulty = difficulty;
+        this.hostId = hostId;
     }
 
     public void addRoomParticipate(RoomParticipate roomParticipate) {


### PR DESCRIPTION
## 👋 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. 테스트 혹은 기능에 대한 사진이 첨부되면 좋습니다!-->

1. room 엔티티에 방 생성자의 id를 host로 저장하였습니다.
게임 입장 시에도 해당 엔티티의 값에 접근하여 host 여부를 판단하는 것으로 수정하였습니다.

2. 중복 입장 시 에러가 뜨는 것이 아니라, 기존 입장 정보를 지우고 최근 입장 정보로 업데이트 하도록 수정하였습니다.
기존 참가자 유저가 중복적으로 입장할 수 있다는 점을 고려해서 가장 최근 정보로 업데이트 하게 하였습니다.


## 📋 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 To Reviewers
<!-- 이번 수정 관련 전달사항이나 의논할 점이 있다면, 전달할 사람을 @{github id}로 멘션하고 작성해주세요! -->
<!-- 특이사항이 없다면 비워두셔도 좋습니다. -->
