### PR TITLE
Chore: #99 RoomState로 중복 검사

### DIFF
--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/GameService.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/GameService.java
@@ -8,10 +8,12 @@ import mutsa.yewon.talksparkbe.domain.cardHolder.dto.TeamCardHolderCreateDTO;
 import mutsa.yewon.talksparkbe.domain.cardHolder.service.StoredCardService;
 import mutsa.yewon.talksparkbe.domain.game.entity.Room;
 import mutsa.yewon.talksparkbe.domain.game.entity.RoomParticipate;
+import mutsa.yewon.talksparkbe.domain.game.repository.RoomParticipateRepository;
 import mutsa.yewon.talksparkbe.domain.game.repository.RoomRepository;
 import mutsa.yewon.talksparkbe.domain.game.service.dto.*;
 import mutsa.yewon.talksparkbe.domain.game.service.util.GameState;
 import mutsa.yewon.talksparkbe.domain.game.service.util.QuestionGenerator;
+import mutsa.yewon.talksparkbe.domain.game.service.util.RoomState;
 import mutsa.yewon.talksparkbe.domain.sparkUser.entity.SparkUser;
 import mutsa.yewon.talksparkbe.global.exception.CustomTalkSparkException;
 import mutsa.yewon.talksparkbe.global.exception.ErrorCode;
@@ -30,13 +32,18 @@ public class GameService {
     private final Map<Long, GameState> gameStates = new HashMap<>();
 
     private final RoomRepository roomRepository;
+    private final RoomParticipateRepository roomParticipateRepository;
     private final QuestionGenerator questionGenerator;
     private final StoredCardService storedCardService;
+    private final RoomState roomState;
 
     @Transactional(readOnly = true)
     public void startGame(Long roomId) {
         Room room = roomRepository.findById(roomId)
                 .orElseThrow(() -> new CustomTalkSparkException(ErrorCode.ROOM_NOT_FOUND));
+
+        System.out.println(roomState.getParticipantsByRoomId(roomId));
+        roomState.clearParticipantsByRoomId(roomId);
 
         List<Card> selectedCards = room.getRoomParticipates().stream()
                 .map(RoomParticipate::getSparkUser)

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/RoomService.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/RoomService.java
@@ -10,6 +10,7 @@ import mutsa.yewon.talksparkbe.domain.game.repository.RoomRepository;
 import mutsa.yewon.talksparkbe.domain.game.service.dto.httpResponse.RoomDetailsResponse;
 import mutsa.yewon.talksparkbe.domain.game.service.dto.httpResponse.RoomListResponse;
 import mutsa.yewon.talksparkbe.domain.game.service.dto.httpResponse.RoomParticipantResponse;
+import mutsa.yewon.talksparkbe.domain.game.service.util.RoomState;
 import mutsa.yewon.talksparkbe.domain.sparkUser.entity.SparkUser;
 import mutsa.yewon.talksparkbe.domain.sparkUser.repository.SparkUserRepository;
 import mutsa.yewon.talksparkbe.global.exception.CustomTalkSparkException;
@@ -39,6 +40,7 @@ public class RoomService {
     private final RedissonClient redissonClient;
     private final StringRedisTemplate redisTemplate;
     private final SecurityUtil securityUtil;
+    private final RoomState roomState;
 
     private final JWTUtil jwtUtil;
 
@@ -68,10 +70,8 @@ public class RoomService {
         Map<String, Object> claims = jwtUtil.validateToken(jwt);
         String kakaoId = (String) claims.get("kakaoId");
         SparkUser sparkUser = sparkUserRepository.findByKakaoId(kakaoId).orElseThrow(() -> new RuntimeException("유저 못찾음"));
-
         // 방에 입장할 때 락을 획득
         RLock lock = redissonClient.getLock("roomLock:" + roomJoinRequest.getRoomId());
-
         try {
             if (lock.tryLock(5, 10, TimeUnit.SECONDS)) { // 최대 대기 시간 5초, 락 보유 시간 10초로 설정
                 if (!canJoin(room, sparkUser)) throw new CustomTalkSparkException(ErrorCode.ROOM_FULL);
@@ -93,8 +93,10 @@ public class RoomService {
         List<RoomParticipantResponse> response = new ArrayList<>();
         List<RoomParticipate> roomParticipates = roomParticipateRepository.findByRoomIdWithSparkUser(roomId);
 
-        for (RoomParticipate rp : roomParticipates)
-            response.add(RoomParticipantResponse.from(rp));
+        for (RoomParticipate rp : roomParticipates){
+            SparkUser participateSparkUser = rp.getSparkUser();
+            response.add(RoomParticipantResponse.from(participateSparkUser, participateSparkUser.getCards().get(0), rp.isOwner()));
+        }
 
         return response;
     }
@@ -170,15 +172,20 @@ public class RoomService {
     }
 
     private boolean canJoin(Room room, SparkUser sparkUser) {
-        if (roomParticipateRepository.findByRoomAndSparkUser(room, sparkUser).isPresent()) {
+        if (roomState.getParticipantsByRoomId(room.getRoomId()).stream().anyMatch(
+                participate -> participate.getSparkUser().getId().equals(sparkUser.getId()))) {
             redisTemplate.opsForHash().increment(ROOM_COUNT_KEY, room.getRoomId().toString(), -1);
+            System.out.println(redisTemplate.opsForHash());
         }
         int currentCount = getParticipateCount(room.getRoomId());
         return currentCount < room.getMaxPeople();
     }
     private void addParticipateToRoom(Room room, SparkUser sparkUser, boolean isHost) {
-        if (roomParticipateRepository.findByRoomAndSparkUser(room, sparkUser).isPresent()) removeParticipateToRoom(room, sparkUser);
+        if (roomState.getParticipantsByRoomId(room.getRoomId()).stream().anyMatch(
+                participate -> participate.getSparkUser().getId().equals(sparkUser.getId()))) return;
+
         RoomParticipate roomParticipate = RoomParticipate.builder().room(room).sparkUser(sparkUser).isOwner(isHost).build();
+        roomState.addParticipant(room.getRoomId(), roomParticipate);
         roomParticipateRepository.save(roomParticipate);
         room.assignRoomParticipate(roomParticipate);
         redisTemplate.opsForHash().increment(ROOM_COUNT_KEY, room.getRoomId().toString(), 1);

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/dto/httpResponse/RoomParticipantResponse.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/dto/httpResponse/RoomParticipantResponse.java
@@ -2,7 +2,9 @@ package mutsa.yewon.talksparkbe.domain.game.service.dto.httpResponse;
 
 import lombok.Builder;
 import lombok.Data;
+import mutsa.yewon.talksparkbe.domain.card.entity.Card;
 import mutsa.yewon.talksparkbe.domain.game.entity.RoomParticipate;
+import mutsa.yewon.talksparkbe.domain.sparkUser.entity.SparkUser;
 
 @Data
 public class RoomParticipantResponse {
@@ -20,12 +22,12 @@ public class RoomParticipantResponse {
         this.isOwner = isOwner;
     }
 
-    public static RoomParticipantResponse from(RoomParticipate roomParticipate) {
+    public static RoomParticipantResponse from(SparkUser sparkUser, Card card, boolean isOwner) {
         return RoomParticipantResponse.builder()
-                .sparkUserId(roomParticipate.getSparkUser().getId())
-                .name(roomParticipate.getSparkUser().getName())
-                .color(roomParticipate.getSparkUser().getCards().get(0).getCardThema().name())
-                .isOwner(roomParticipate.isOwner())
+                .sparkUserId(sparkUser.getId())
+                .name(card.getName())
+                .color(card.getCardThema().name())
+                .isOwner(isOwner)
                 .build();
     }
 

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/util/RoomState.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/util/RoomState.java
@@ -1,0 +1,44 @@
+package mutsa.yewon.talksparkbe.domain.game.service.util;
+
+import lombok.Getter;
+import lombok.Setter;
+import mutsa.yewon.talksparkbe.domain.card.entity.Card;
+import mutsa.yewon.talksparkbe.domain.game.entity.RoomParticipate;
+import mutsa.yewon.talksparkbe.domain.game.service.dto.CardQuestion;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@Component
+public class RoomState {
+
+    private final Map<Long, List<RoomParticipate>> roomParticipants = new HashMap<>();
+
+    public boolean existRoomId(long roomId) {
+        return roomParticipants.containsKey(roomId);
+    }
+
+    public void addParticipant(Long roomId, RoomParticipate participant) {
+        roomParticipants.computeIfAbsent(roomId, k -> new ArrayList<>()).add(participant);
+    }
+
+    public List<RoomParticipate> getParticipantsByRoomId(Long roomId) {
+        return roomParticipants.getOrDefault(roomId, new ArrayList<>());
+    }
+
+    public void removeParticipant(Long roomId, RoomParticipate participant) {
+        List<RoomParticipate> participants = roomParticipants.get(roomId);
+        if (participants != null) {
+            participants.remove(participant);
+        }
+    }
+
+    public void clearParticipantsByRoomId(Long roomId) {
+        roomParticipants.remove(roomId);
+    }
+}


### PR DESCRIPTION
## 👋 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. 테스트 혹은 기능에 대한 사진이 첨부되면 좋습니다!-->
1. 게임 방에 들어왔을 때 참가자 엔티티에 저장함과 동시에 RoomState 객체(단기 캐시)에 저장해놓습니다.

원래는 게임 시작하기 전에 RoomState에 저장하고 시작할 때 참가자 엔티티에 한번에 저장하게 코드를 구현했었는데, `roomParticipate.getSparkUser().getCards()`부분에서 계속 `방 참가 중 오류 발생: failed to lazily initialize a collection of role: mutsa.yewon.talksparkbe.domain.sparkUser.entity.SparkUser.cards: could not initialize proxy - no Session` 에러가 뜨는 바람에..그렇게는 구현하지 못했습니다.

좀 더 찾아봐야하긴 하는데 현재 코드 상에서는 프론트에서` leaveRoom`요청을 보내지 않는 것 같아서..(=> 참가자 엔티티에서 참가자 정보를 제거하는 로직이 실행되지 않음) 아직까지는 이렇게 수정해도 괜찮을 것 같아 처음에 참가자 엔티티를 저장하되, 중복 검사를 할 때는 DB에 접근하여 읽는 연산을 줄이고 RoomState로 해결하도록..수정해보았습니다..! 
(leaveRoom 요청을 보내는 부분이 있는지 프론트 맡으신 분한테 물어봐야할 것 같습니다!)

2. 현재 게임 대기에서 카카오 로그인 때 받아온 정보(ex) 이름) 데이터를 쓰는 것을 Card 데이터를 쓰도록 변경하였습니다..

## 📋 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 To Reviewers
<!-- 이번 수정 관련 전달사항이나 의논할 점이 있다면, 전달할 사람을 @{github id}로 멘션하고 작성해주세요! -->
<!-- 특이사항이 없다면 비워두셔도 좋습니다. -->
