### PR TITLE
Refactor: #129 게임 종료 처리 시 각 유저 별 http 요청을 받아 처리하도록 API 구현

### DIFF
--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/GameEndController.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/GameEndController.java
@@ -1,0 +1,35 @@
+package mutsa.yewon.talksparkbe.domain.game.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import mutsa.yewon.talksparkbe.domain.game.controller.dto.EndGameDto;
+import mutsa.yewon.talksparkbe.domain.game.controller.dto.EndGameResponseDto;
+import mutsa.yewon.talksparkbe.domain.game.controller.swagger.GameEndControllerDocs;
+import mutsa.yewon.talksparkbe.domain.game.service.GameService;
+import mutsa.yewon.talksparkbe.domain.game.service.RoomService;
+import mutsa.yewon.talksparkbe.domain.game.service.dto.CardResponseCustomDTO;
+import mutsa.yewon.talksparkbe.global.dto.ResponseDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class GameEndController implements GameEndControllerDocs {
+
+    private final GameService gameService;
+
+    @PostMapping("/api/game/end")
+    public ResponseEntity<ResponseDTO<EndGameResponseDto>> endGame(@RequestBody EndGameDto endGameDto) {
+        return ResponseEntity.ok(ResponseDTO.ok("플레이어 명함 저장 완료.",
+                gameService.endGame(endGameDto)));
+    }
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/RoomSocketIOHandler.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/RoomSocketIOHandler.java
@@ -5,8 +5,6 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import mutsa.yewon.talksparkbe.domain.card.entity.Card;
-import mutsa.yewon.talksparkbe.domain.card.entity.CardThema;
 import mutsa.yewon.talksparkbe.domain.card.repository.CardRepository;
 import mutsa.yewon.talksparkbe.domain.game.controller.request.*;
 import mutsa.yewon.talksparkbe.domain.game.service.dto.CardQuestion;
@@ -20,7 +18,6 @@ import mutsa.yewon.talksparkbe.global.exception.CustomTalkSparkException;
 import mutsa.yewon.talksparkbe.global.util.JWTUtil;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import mutsa.yewon.talksparkbe.global.util.SecurityUtil;
 
 import java.util.List;
 import java.util.Map;
@@ -174,15 +171,15 @@ public class RoomSocketIOHandler {
 //            }
         });
 
-        server.addEventListener("getEnd", EndRequest.class, (client, data, ackSender) -> {
-            Long sparkUserId = data.getSparkUserId();
-            Long roomId = data.getRoomId();
-
-            server.getRoomOperations(roomId.toString()).sendEvent("scores", gameService.getScores(roomId), gameService.getAllRelatedCards(roomId));
-            gameService.insertCardCopies(roomId, sparkUserId);
-            gameService.endGame(roomId); // 게임 종료 시 저장하고 있던 게임 정보는 삭제
-            roomService.changeFinished(roomId);
-        });
+//        server.addEventListener("getEnd", EndRequest.class, (client, data, ackSender) -> {
+//            Long sparkUserId = data.getSparkUserId();
+//            Long roomId = data.getRoomId();
+//
+//            server.getRoomOperations(roomId.toString()).sendEvent("scores", gameService.getScores(roomId), gameService.getAllRelatedCards(roomId));
+//            gameService.insertCardCopies(roomId, sparkUserId);
+//            gameService.removeGameState(roomId); // 게임 종료 시 저장하고 있던 게임 정보는 삭제
+//            roomService.changeFinished(roomId);
+//        });
     }
 
     private void sendSingleResult(Long roomId) {

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/dto/EndGameDto.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/dto/EndGameDto.java
@@ -1,0 +1,21 @@
+package mutsa.yewon.talksparkbe.domain.game.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EndGameDto {
+
+    @Schema(description = "방 식별자", example = "1")
+    private Long roomId;
+
+    @Schema(description = "게임 참가자 식별자", example = "2")
+    private Long playerId;
+
+    public EndGameDto(Long roomId, Long playerId) {
+        this.roomId = roomId;
+        this.playerId = playerId;
+    }
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/dto/EndGameResponseDto.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/dto/EndGameResponseDto.java
@@ -1,0 +1,25 @@
+package mutsa.yewon.talksparkbe.domain.game.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import mutsa.yewon.talksparkbe.domain.game.service.dto.CardResponseCustomDTO;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class EndGameResponseDto {
+
+    @Schema(description = "최종 점수판", example = "{1 : 10, 2 : 5}")
+    private Map<Long, Integer> scores;
+
+    @ArraySchema(arraySchema = @Schema(description = "게임에 참여한 모든 참여자 명함들"))
+    private List<CardResponseCustomDTO> allPlayedCards;
+
+    public static EndGameResponseDto of(Map<Long, Integer> scores,List<CardResponseCustomDTO> allPlayedCards ){
+        return new EndGameResponseDto(scores, allPlayedCards);
+    }
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/swagger/GameEndControllerDocs.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/controller/swagger/GameEndControllerDocs.java
@@ -1,0 +1,22 @@
+package mutsa.yewon.talksparkbe.domain.game.controller.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import mutsa.yewon.talksparkbe.domain.game.controller.dto.EndGameDto;
+import mutsa.yewon.talksparkbe.domain.game.controller.dto.EndGameResponseDto;
+import mutsa.yewon.talksparkbe.global.dto.ResponseDTO;
+import mutsa.yewon.talksparkbe.global.exception.ErrorCode;
+import mutsa.yewon.talksparkbe.global.swagger.ApiErrorCodes;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "게임 종료 API")
+public interface GameEndControllerDocs {
+
+    @Operation(summary = "게임 종료 처리 API", description = "게임 종료 시 최종 점수를 공개하고 사용자 명함들을 모두 저장합니다.")
+    @ApiErrorCodes({ErrorCode.GAME_NOT_FOUND})
+    ResponseEntity<ResponseDTO<EndGameResponseDto>> endGame(@RequestBody EndGameDto endGameDto);
+}

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/dto/CardResponseCustomDTO.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/dto/CardResponseCustomDTO.java
@@ -1,5 +1,6 @@
 package mutsa.yewon.talksparkbe.domain.game.service.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,30 +12,43 @@ import mutsa.yewon.talksparkbe.domain.card.entity.CardThema;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Schema(description = "게임 종료 후 참여한 인원의 명함 정보를 반환하는 DTO")
 public class CardResponseCustomDTO {
 
+    @Schema(description = "카드의 고유 ID", example = "1")
     private Long id;
 
+    @Schema(description = "카카오 로그인 ID", example = "kakao_123456")
     private String kakaoId;
 
+    @Schema(description = "사용자 이름", example = "김철수")
     private String name;
 
+    @Schema(description = "사용자 나이", example = "25")
     private Integer age;
 
+    @Schema(description = "사용자 전공", example = "컴퓨터공학")
     private String major;
 
+    @Schema(description = "사용자의 MBTI", example = "INTP")
     private String mbti;
 
+    @Schema(description = "사용자의 취미", example = "축구")
     private String hobby;
 
+    @Schema(description = "닮은 연예인", example = "박보검")
     private String lookAlike;
 
+    @Schema(description = "사용자 자기소개", example = "안녕하세요! 저는 개발자입니다.")
     private String selfDescription;
 
+    @Schema(description = "사용자의 TMI", example = "라면을 좋아해요.")
     private String tmi;
 
+    @Schema(description = "카드 소유자의 ID", example = "1001")
     private Long ownerId;
 
+    @Schema(description = "카드의 테마", example = "BLUE")
     private CardThema cardThema;
 
     public static CardResponseCustomDTO fromCard(Card card) {

--- a/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/util/GameState.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/domain/game/service/util/GameState.java
@@ -24,10 +24,15 @@ public class GameState {
 
     public GameState(List<Card> cards, List<UserCardQuestions> userCardQuestions) {
         this.questions = new LinkedList<>();
-        userCardQuestions.forEach(q -> {
-                    playerInfo.put(q.getSparkUserId(), matchToQuestion(cards, q.getSparkUserId()));
-                    questions.addAll(q.getQuestions());
-                });
+        for (UserCardQuestions q : userCardQuestions) {
+            playerInfo.put(q.getSparkUserId(), matchToQuestion(cards, q.getSparkUserId()));
+            questions.addAll(q.getQuestions());
+            scores.put(q.getSparkUserId(), 0);
+        }
+//        userCardQuestions.forEach(q -> {
+//                    playerInfo.put(q.getSparkUserId(), matchToQuestion(cards, q.getSparkUserId()));
+//                    questions.addAll(q.getQuestions());
+//                });
         this.currentSubjectId = userCardQuestions.get(0).getSparkUserId();
     }
 

--- a/src/main/java/mutsa/yewon/talksparkbe/global/dto/ResponseDTO.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/global/dto/ResponseDTO.java
@@ -7,13 +7,13 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-@Schema(description = "API 응답 DTO")
+@Schema(description = "API 응답 DTO", oneOf = { ResponseDTO.class })
 public class ResponseDTO<D> {
 
-    @Schema(description = "응답 상태 코드")
+    @Schema(description = "응답 상태 코드", example = "200")
     private final int status;
 
-    @Schema(description = "응답 메세지")
+    @Schema(description = "응답 메세지", example = "api 응답 메세지")
     private final String message;
 
     @Schema(description = "응답 데이터")

--- a/src/main/java/mutsa/yewon/talksparkbe/global/exception/ErrorCode.java
+++ b/src/main/java/mutsa/yewon/talksparkbe/global/exception/ErrorCode.java
@@ -29,7 +29,8 @@ public enum ErrorCode {
     CARDHOLDER_NOT_EXIST(HttpStatus.NOT_FOUND, "해당하는 명함은 저장된 이력이 없습니다."),
     NO_BOOKMARKED_CONTENT(HttpStatus.NOT_FOUND, "즐겨찾기 된 명함이 없습니다."),
     NO_MATCHING_CARDHOLDER(HttpStatus.NOT_FOUND, "해당하는 이름의 명함이 존재하지 않습니다."),
-    NOT_ROOM_USER(HttpStatus.NOT_FOUND, "해당 방의 참여자가 아닙니다.");
+    NOT_ROOM_USER(HttpStatus.NOT_FOUND, "해당 방의 참여자가 아닙니다."),
+    GAME_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 방에 진행중인 게임이 없습니다.");
 
 
 


### PR DESCRIPTION
## 👋 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closes #129 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. 테스트 혹은 기능에 대한 사진이 첨부되면 좋습니다!-->

게임 종료 시 더 이상 Socket.Io를 바탕으로 요청을 보내지 않고 각 유저별 http 요청을 통해 유저가 본인이 원하는 순간에 점수판을 각자 확인할 수 있도록 구현하였습니다.

## 📋 PR 유형
어떤 변경 사항이 있나요?

1. GameService 내 endGame() 메서드 추가

2. GameEndController 추가

3.  GameEndControllerDocs 로 문서화

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📣 To Reviewers
<!-- 이번 수정 관련 전달사항이나 의논할 점이 있다면, 전달할 사람을 @{github id}로 멘션하고 작성해주세요! -->
<!-- 특이사항이 없다면 비워두셔도 좋습니다. -->
